### PR TITLE
testing concatenated buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/mcollina/msgpack5",
   "devDependencies": {
+    "bl": "^0.9.3",
     "faucet": "0.0.1",
     "jshint": "^2.5.2",
     "pre-commit": "0.0.9",

--- a/test/streams.js
+++ b/test/streams.js
@@ -1,6 +1,7 @@
 
 var test        = require('tape').test
   , msgpack     = require('../')
+  , BufferList  = require('bl')
 
 test('must send an object through', function(t) {
   t.plan(1)
@@ -182,4 +183,32 @@ test('decoding error wrapped', function(t) {
   encoder.end(data)
 
   encoder.pipe(decoder)
+})
+
+test('concatenated buffers work', function(t) {
+  var pack    = msgpack()
+    , encoder = pack.encoder()
+    , decoder = pack.decoder()
+    , data    = [
+        { hello: 1 }
+      , { hello: 2 }
+      , { hello: 3 }
+    ]
+
+  t.plan(data.length)
+
+  var bl = new BufferList()
+  encoder.on('data', bl.append.bind(bl))
+
+  data.forEach(encoder.write.bind(encoder))
+
+  decoder.on('data', function(d) {
+    t.deepEqual(d, data.shift())
+  })
+
+  encoder.once('finish', function() {
+    decoder.write(bl.slice())
+  })
+
+  encoder.end()
 })


### PR DESCRIPTION
@mcollina I'm having trouble with the streaming decoder, and I'm not sure if I'm doing this right.

I added a test case where, instead of writing one buffer at a time, I write one single buffer with all the buffers concatenated, and it's failing.

Shouldn't this work?
