### PR TITLE
Use msgpack5 as a level encoding straight away

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,29 @@ Builds a stream in object mode that decodes msgpack. By default it expects
 msgpack to have a 4 byte length header containing the packaged length as
 a UInt32BE. This header can be disabled by passing `{ header: false }` as an option.
 
+LevelUp Support
+---------------
+
+__msgpack5__ can be used as a LevelUp
+[`valueEncoding`](https://github.com/rvagg/node-levelup#leveluplocation-options-callback) straight away:
+
+```js
+var level = require('level')
+  , pack  = msgpack()
+  , db    = level('foo', {
+      valueEncoding: pack
+    })
+  , obj   = { my: 'obj' }
+
+db.put('hello', obj, function(err) {
+  db.get('hello', function(err, result) {
+    console.log(result)
+    db.close()
+  })
+})
+
+```
+
 Disclaimer
 ----------
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function msgpack() {
   var encodingTypes = []
     , decodingTypes = []
 
-  function encode(obj) {
+  function encode(obj, avoidSlice) {
     var buf
       , len
 
@@ -79,7 +79,7 @@ function msgpack() {
       }
 
       buf = obj.reduce(function(acc, obj) {
-        acc.append(encode(obj))
+        acc.append(encode(obj, true))
         return acc
       }, bl().append(buf))
     } else if (typeof obj === 'object') {
@@ -132,7 +132,10 @@ function msgpack() {
     if (!buf)
       throw new Error('not implemented yet')
 
-    return buf
+    if (avoidSlice)
+      return buf
+    else
+      return buf.slice()
   }
 
   function decode(buf) {
@@ -343,8 +346,8 @@ function msgpack() {
           obj[key] !== undefined &&
           "function" !== typeof obj[key] ) {
         ++length
-        acc.push(encode(key))
-        acc.push(encode(obj[key]))
+        acc.push(encode(key, true))
+        acc.push(encode(obj[key], true))
       }
     }
 
@@ -498,6 +501,10 @@ function msgpack() {
     , registerDecoder: registerDecoder
     , encoder: streams.encoder
     , decoder: streams.decoder
+
+    // needed for levelup support
+    , buffer: true
+    , type: 'msgpack5'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,15 +30,16 @@
   },
   "homepage": "https://github.com/mcollina/msgpack5",
   "devDependencies": {
-    "bl": "^0.9.3",
     "faucet": "0.0.1",
     "jshint": "^2.5.2",
+    "level": "^0.18.0",
+    "level-test": "^1.6.6",
     "pre-commit": "0.0.9",
     "tap": "^0.4.11",
     "tape": "^2.14.0"
   },
   "dependencies": {
-    "bl": "^0.9.0",
+    "bl": "^0.9.3",
     "inherits": "^2.0.1",
     "readable-stream": "^1.0.27-1"
   }

--- a/test/levelup-encoding.js
+++ b/test/levelup-encoding.js
@@ -45,3 +45,24 @@ test('msgpack level encoding get', function(t) {
     })
   })
 })
+
+test('msgpack level encoding mirror', function(t) {
+  t.plan(4)
+
+  var pack  = msgpack()
+    , db    = level('foo', {
+        valueEncoding: pack
+      })
+    , obj   = { my: 'obj' }
+
+  db.put('hello', obj, function(err) {
+    t.error(err, 'putting has no errors')
+    db.get('hello', function(err, result) {
+      t.error(err, 'get has no error')
+      t.deepEqual(result, obj)
+      db.close(function() {
+        t.pass('db closed')
+      })
+    })
+  })
+})

--- a/test/levelup-encoding.js
+++ b/test/levelup-encoding.js
@@ -1,0 +1,47 @@
+
+var test    = require('tape').test
+  , level   = require('level-test')()
+  , msgpack = require('../')
+
+test('msgpack level encoding put', function(t) {
+  t.plan(4)
+
+  var pack  = msgpack()
+    , db    = level('foo', {
+        valueEncoding: pack
+      })
+    , obj   = { my: 'obj' }
+
+  db.put('hello', obj, function(err) {
+    t.error(err, 'put has no errors')
+    db.get('hello', { valueEncoding: 'binary'}, function(err, buf) {
+      t.error(err, 'get has no error')
+      t.deepEqual(pack.decode(buf), obj)
+      db.close(function() {
+        t.pass('db closed')
+      })
+    })
+  })
+})
+
+test('msgpack level encoding get', function(t) {
+  t.plan(4)
+
+  var pack  = msgpack()
+    , db    = level('foo', {
+        valueEncoding: pack
+      })
+    , obj   = { my: 'obj' }
+    , buf   = pack.encode(obj)
+
+  db.put('hello', buf, { valueEncoding: 'binary'}, function(err) {
+    t.error(err, 'putting has no errors')
+    db.get('hello', function(err, result) {
+      t.error(err, 'get has no error')
+      t.deepEqual(result, obj)
+      db.close(function() {
+        t.pass('db closed')
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR makes it possible to:

```js
var level = require('level')
  , pack  = msgpack()
  , db    = level('foo', {
      valueEncoding: pack
    })
  , obj   = { my: 'obj' }

db.put('hello', obj, function(err) {
  db.get('hello', function(err, result) {
    console.log(result)
    db.close()
  })
})
```
