### PR TITLE
Encode int64 numbers

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -114,8 +114,9 @@ module.exports = function buildDecode(decodingTypes) {
 
     var first = buf.readUInt8(offset)
       , length
-      , result
+      , result = 0
       , type
+	  , bytePos
 
     if (!hasMinBufferSize(first, bufLength)) {
       return null
@@ -142,10 +143,9 @@ module.exports = function buildDecode(decodingTypes) {
         return buildDecodeResult(result, 5)
       case 0xcf:
         // 8-bytes BE unsigned int
-		// Read long byte by byte, big-endian
-        var result = 0;
-        for (var k = 7; k >= 0; k--) {
-            result += (buf.readUInt8(offset + k + 1) * Math.pow(2 , (8 *(7-k))));
+        // Read long byte by byte, big-endian
+        for (bytePos = 7; bytePos >= 0; bytePos--) {
+          result += (buf.readUInt8(offset + bytePos + 1) * Math.pow(2 , (8 *(7-bytePos))));
         }
         return buildDecodeResult(result, 9)
       case 0xd0:

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -142,7 +142,11 @@ module.exports = function buildDecode(decodingTypes) {
         return buildDecodeResult(result, 5)
       case 0xcf:
         // 8-bytes BE unsigned int
-        result = buf.readUInt32BE(offset + 5) * 0xffffffff + buf.readUInt32BE(offset + 1)
+		// Read long byte by byte, big-endian
+        var result = 0;
+        for (var k = 7; k >= 0; k--) {
+            result += (buf.readUInt8(offset + k + 1) * Math.pow(2 , (8 *(7-k))));
+        }
         return buildDecodeResult(result, 9)
       case 0xd0:
         // 1-byte signed int

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -219,9 +219,11 @@ module.exports = function buildEncode(encodingTypes) {
 }
 
 function write64BitUint(buf, obj) {
-  var big = Math.floor(obj / 0xffffffff)
-  buf.writeUInt32BE(big, 5)
-  buf.writeUInt32BE(obj - big * 0xffffffff, 1)
+   // Write long byte by byte, in big-endian order
+  for (var k = 7; k >= 0; k--) {
+        buf[k + 1] = (obj & 0xff);
+        obj = obj / 256;
+    }
 }
 
 function isFloat(n) {

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -220,10 +220,10 @@ module.exports = function buildEncode(encodingTypes) {
 
 function write64BitUint(buf, obj) {
    // Write long byte by byte, in big-endian order
-  for (var k = 7; k >= 0; k--) {
-        buf[k + 1] = (obj & 0xff);
-        obj = obj / 256;
-    }
+  for (var currByte = 7; currByte >= 0; currByte--) {
+    buf[currByte + 1] = (obj & 0xff);
+    obj = obj / 256;
+  }
 }
 
 function isFloat(n) {

--- a/test/64-bits-unsigned-integers.js
+++ b/test/64-bits-unsigned-integers.js
@@ -22,6 +22,7 @@ test('encoding/decoding 64-bits big-endian unsigned integers', function(t) {
       for (var k = 7; k >= 0; k--) {
            result += (buf.readUInt8(k + 1) * Math.pow(2 , (8 *(7-k))));
        }
+      t.equal(result, num, 'must decode correctly');
       t.end()
     })
 

--- a/test/64-bits-unsigned-integers.js
+++ b/test/64-bits-unsigned-integers.js
@@ -18,7 +18,10 @@ test('encoding/decoding 64-bits big-endian unsigned integers', function(t) {
       var buf = encoder.encode(num)
       t.equal(buf.length, 9, 'must have 9 bytes')
       t.equal(buf[0], 0xcf, 'must have the proper header')
-      t.equal(buf.readUInt32BE(5) * base + buf.readUInt32BE(1), num, 'must decode correctly');
+      var result = 0; 
+      for (var k = 7; k >= 0; k--) {
+           result += (buf.readUInt8(k + 1) * Math.pow(2 , (8 *(7-k))));
+       }
       t.end()
     })
 


### PR DESCRIPTION
Hey,
I changed the int64 encoding/decoding functions to encode them like the spec defines.
This doesn't handle precision issues, as I haven't changed the type, I just changed the way the bytes are written to the output.
I've tested it, and it interoperates against the java msgpack library correctly.