### PR TITLE
Typed numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,29 @@ db.put('hello', obj, function(err) {
 
 ```
 
+Support for typed numbers
+-------------------------
+
+When you use Message Pack to communicate with a typed language like Java that has more than one type for numbers, the default configuration of this library might be problematic for you:
+
+When you receive and decode the double `1.1` from a Java API, it will be converted to the JavaScript number `1.1`. When you encode it again, it will be encoded as a float (not a double). This will lead to another type being returned from the Java decoder than the Java developer expected.
+
+To solve this, you can activate the option `typedNumbers`:
+
+```js
+var encoder = msgpack({ typedNumbers: true })
+```
+
+This will return numbers wrapped in a `TypedNumber`. A `TypedNumber` has a `value` which is the number itself and a `type`. This information will be used again when you encode the value. You can also use `TypedNumber` when sending information to the API:
+
+```js
+var encoder = msgpack({ typedNumbers: true })
+  , TypedNumber = encoder.TypedNumber
+  , typedDouble = new TypedNumber(12, 'double')
+
+buf = encoder.encode(typedDouble) // buf will now be encoded as a double
+```
+
 Disclaimer
 ----------
 

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ var assert      = require('assert')
   , buildEncode = require('./lib/encoder')
   , TypedNumber = require('./lib/typed_number').TypedNumber
 
-function msgpack() {
+function msgpack(opts) {
 
   var encodingTypes = []
     , decodingTypes = []
+    , options = opts || {}
 
   function registerEncoder(check, encode) {
     assert(check, 'must have an encode function')
@@ -65,7 +66,7 @@ function msgpack() {
 
   return {
       encode: buildEncode(encodingTypes)
-    , decode: buildDecode(decodingTypes)
+    , decode: buildDecode(decodingTypes, options)
     , register: register
     , registerEncoder: registerEncoder
     , registerDecoder: registerDecoder

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var assert      = require('assert')
   , streams     = require('./lib/streams')
   , buildDecode = require('./lib/decoder')
   , buildEncode = require('./lib/encoder')
+  , TypedNumber = require('./lib/typed_number').TypedNumber
 
 function msgpack() {
 
@@ -70,6 +71,7 @@ function msgpack() {
     , registerDecoder: registerDecoder
     , encoder: streams.encoder
     , decoder: streams.decoder
+    , TypedNumber: TypedNumber
 
     // needed for levelup support
     , buffer: true

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,5 +1,6 @@
 var bl   = require('bl')
   , util = require('util')
+  , TypedNumber = require('./typed_number').TypedNumber
 
 function IncompleteBufferError(message) {
   Error.call(this); //super constructor
@@ -11,7 +12,14 @@ function IncompleteBufferError(message) {
 util.inherits(IncompleteBufferError, Error)
 
 
-module.exports = function buildDecode(decodingTypes) {
+module.exports = function buildDecode(decodingTypes, opts) {
+  var wrapNumber = function (number) { return number; };
+
+  if (opts.typedNumbers) {
+    wrapNumber = function (number, type) {
+      return new TypedNumber(number, type);
+    };
+  }
 
   return decode;
 
@@ -169,7 +177,7 @@ module.exports = function buildDecode(decodingTypes) {
         return buildDecodeResult(result, 5)
       case 0xcb:
         // 8-bytes double
-        result = buf.readDoubleBE(offset + 1)
+        result = wrapNumber(buf.readDoubleBE(offset + 1), 'double')
         return buildDecodeResult(result, 9)
       case 0xd9:
         // strings up to 2^8 - 1 bytes

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -76,6 +76,14 @@ module.exports = function buildEncode(encodingTypes) {
         acc.append(encode(obj, true))
         return acc
       }, bl().append(buf))
+    } else if (obj.isTypedNumber) {
+      if (obj.numberType == 'double') {
+        buf = new Buffer(9)
+        buf[0] = 0xcb
+        buf.writeDoubleBE(obj.value, 1)
+      } else {
+        throw new Error('Unknown Type of TypedNumber')
+      }
     } else if (typeof obj === 'object') {
       buf = encodeExt(obj) || encodeObject(obj)
     } else if (typeof obj === 'number') {

--- a/lib/typed_number.js
+++ b/lib/typed_number.js
@@ -1,0 +1,13 @@
+/* TypedNumber
+ *
+ * A TypedNumber is a wrapper around a JavaScript number that knows
+ * which type the number has (double for example) so it can be serialized
+ * accordingly.
+ */
+var TypedNumber = function (value, numberType) {
+  this.value = value
+  this.numberType = numberType
+  this.isTypedNumber = true
+};
+
+module.exports.TypedNumber = TypedNumber

--- a/test/typed_numbers.js
+++ b/test/typed_numbers.js
@@ -8,7 +8,7 @@ test('Warn if the type of number is unknown', function (t) {
 
   t.throws(function () {
     encoder.encode(typedDouble)
-  }, /unknown type of typed number/i, "Should raise an error if the type of number is not known")
+  }, /unknown type of typednumber/i, "Should raise an error if the type of number is not known")
 
   t.end()
 })
@@ -24,3 +24,17 @@ test('Encoding a double', function(t) {
 
   t.end()
 })
+
+test('Decoding a double as typed', function(t) {
+  var encoder = msgpack({ typedNumbers: true })
+    , TypedNumber = encoder.TypedNumber
+    , typedDouble = new TypedNumber(12.0, 'double')
+    , buf = encoder.encode(typedDouble)
+    , decoded = encoder.decode(buf)
+
+  t.ok(decoded.isTypedNumber, 'must be a typed number')
+  t.equal(decoded.value, 12.0, 'must have the same value')
+  t.equal(decoded.numberType, 'double', 'must be a double')
+
+  t.end()
+});

--- a/test/typed_numbers.js
+++ b/test/typed_numbers.js
@@ -1,0 +1,26 @@
+var test    = require('tape').test
+  , msgpack = require('../')
+
+test('Warn if the type of number is unknown', function (t) {
+  var encoder = msgpack()
+    , TypedNumber = encoder.TypedNumber
+    , typedDouble = new TypedNumber(12.0, 'fouble')
+
+  t.throws(function () {
+    encoder.encode(typedDouble)
+  }, /unknown type of typed number/i, "Should raise an error if the type of number is not known")
+
+  t.end()
+})
+
+test('Encoding a double', function(t) {
+  var encoder = msgpack()
+    , TypedNumber = encoder.TypedNumber
+    , typedDouble = new TypedNumber(12.0, 'double')
+    , buf = encoder.encode(typedDouble)
+
+  t.equal(buf.length, 9, 'must have 5 bytes')
+  t.equal(buf[0], 0xcb, 'must have the proper header');
+
+  t.end()
+})


### PR DESCRIPTION
I'm using Message Pack to communicate between Java and JavaScript – using your great library (thanks for that!). We ran into a problem when transferring numbers though. The setup is as follows:

A Java program sends a request to Node.js (using Message Pack), Node.js does some work on the data, sends it to another Java program (using Message Pack). We noticed that the numbers were scrambled. 

The reason for that is simple: You are always using the smallest number format possible to encode this specific number. This however leads to the effect described above, rendering the library unusable for us.

My solution introduces TypedNumbers which are tiny wrappers around JS Numbers:

```js
var encoder = msgpack()
  , TypedNumber = encoder.TypedNumber
  , typedDouble = new TypedNumber(12, 'double')

buf = encoder.encode(typedDouble) // buf will now be encoded as a double
```

If you encode a JavaScript Number without a wrapper, it will continue to work as it does now – choose the smallest number type possible for encoding.

For decoding however, the library needs to know if you like typed numbers or "normal" numbers. Therefore I introduced an option in this PR:

```js
var encoder = msgpack({ typedNumbers: true })
```

If you decode a double with this option you will receive a TypedNumber of the type `double` instead of a Number.

This PR is only implementing this functionality for `doubles`, as I wanted to get your feedback first before implementing it for all types of numbers. What do you think?