### PR TITLE
Check if Error has a captureStackTrace method before invoking it

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -3,7 +3,9 @@ var bl   = require('bl')
 
 function IncompleteBufferError(message) {
   Error.call(this); //super constructor
-  Error.captureStackTrace(this, this.constructor); //super helper method to include stack trace in error object
+  if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor); //super helper method to include stack trace in error object
+  }
   this.name = this.constructor.name
   this.message = message || "unable to decode"
 }


### PR DESCRIPTION
Error lacks a captureStackTrace method in IE. By adding this check we get closer to support for IE 10. I am still experiencing issues getting encoding and decoding working on IE 10.