### PR TITLE
add forceFloat64 flag to encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,14 @@ API
 
 -------------------------------------------------------
 <a name="msgpack"></a>
-### msgpack()
+### msgpack(options(obj))
 
 Creates a new instance on which you can register new types for being
 encoded.
+
+options:
+
+- `forceFloat64`, a boolean to that forces all floats to be encoded as 64-bits floats. Defaults is false.
 
 -------------------------------------------------------
 <a name="encode"></a>

--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ var assert      = require('assert')
   , buildDecode = require('./lib/decoder')
   , buildEncode = require('./lib/encoder')
 
-function msgpack() {
+function msgpack(options) {
 
   var encodingTypes = []
     , decodingTypes = []
+
+  options = options ? options : { forceFloat64: false }
 
   function registerEncoder(check, encode) {
     assert(check, 'must have an encode function')
@@ -63,7 +65,7 @@ function msgpack() {
   }
 
   return {
-      encode: buildEncode(encodingTypes)
+      encode: buildEncode(encodingTypes, options.forceFloat64)
     , decode: buildDecode(decodingTypes)
     , register: register
     , registerEncoder: registerEncoder

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -3,7 +3,7 @@ var bl        = require('bl')
   , TOLERANCE = 0.1
 
 module.exports = function buildEncode(encodingTypes) {
-  function encode(obj, avoidSlice) {
+  function encode(obj, avoidSlice, forceFloat64) {
     var buf
       , len
 
@@ -80,7 +80,7 @@ module.exports = function buildEncode(encodingTypes) {
       buf = encodeExt(obj) || encodeObject(obj)
     } else if (typeof obj === 'number') {
       if (isFloat(obj)) {
-        return encodeFloat(obj)
+        return encodeFloat(obj, forceFloat64)
       } else if (obj >= 0) {
         if (obj < 128) {
           buf = new Buffer(1)
@@ -230,7 +230,7 @@ function isFloat(n) {
   return n !== Math.floor(n)
 }
 
-function encodeFloat(obj) {
+function encodeFloat(obj, forceFloat64) {
   var buf
 
   buf = new Buffer(5)
@@ -239,7 +239,7 @@ function encodeFloat(obj) {
 
   // FIXME is there a way to check if a
   // value fits in a float?
-  if (Math.abs(obj - buf.readFloatBE(1)) > TOLERANCE) {
+  if (forceFloat64 || Math.abs(obj - buf.readFloatBE(1)) > TOLERANCE) {
     buf = new Buffer(9)
     buf[0] = 0xcb
     buf.writeDoubleBE(obj, 1)

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -2,8 +2,8 @@
 var bl        = require('bl')
   , TOLERANCE = 0.1
 
-module.exports = function buildEncode(encodingTypes) {
-  function encode(obj, avoidSlice, forceFloat64) {
+module.exports = function buildEncode(encodingTypes, forceFloat64) {
+  function encode(obj, avoidSlice) {
     var buf
       , len
 

--- a/test/floats.js
+++ b/test/floats.js
@@ -22,7 +22,8 @@ test('encoding/decoding 32-bits float numbers', function(t) {
     })
 
     t.test('forceFloat64 encoding ' + num, function(t) {
-      var buf = encoder.encode(num, false, true)
+      var enc = msgpack({ forceFloat64: true })
+        , buf = enc.encode(num)
         , dec = buf.readDoubleBE(1)
       t.equal(buf.length, 9, 'must have 9 bytes')
       t.equal(buf[0], 0xcb, 'must have the proper header');

--- a/test/floats.js
+++ b/test/floats.js
@@ -21,6 +21,15 @@ test('encoding/decoding 32-bits float numbers', function(t) {
       t.end()
     })
 
+    t.test('forceFloat64 encoding ' + num, function(t) {
+      var buf = encoder.encode(num, false, true)
+        , dec = buf.readDoubleBE(1)
+      t.equal(buf.length, 9, 'must have 9 bytes')
+      t.equal(buf[0], 0xcb, 'must have the proper header');
+      t.true(Math.abs(dec - num) < 0.1, 'must decode correctly');
+      t.end()
+    })
+
     t.test('decoding ' + num, function(t) {
       var buf = new Buffer(5)
         , dec


### PR DESCRIPTION
fix https://github.com/mcollina/msgpack5/issues/30

Should we expose flags e.g. `avoidSlice`, `forceFloat64` to top-level namespace?

e.g. `var msgpack = require('msgpack5')({ avoidSlice: false, forceFloat64: true })`