### PR TITLE
Introduced compatibilityMode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ encoded.
 
 options:
 
-- `forceFloat64`, a boolean to that forces all floats to be encoded as 64-bits floats. Defaults is false.
+- `forceFloat64`, a boolean to that forces all floats to be encoded as 64-bits floats. Defaults to false.
+- `compatibilityMode`, a boolean that enables "compatibility mode" which doesn't use str 8 format. Defaults to false.
 
 -------------------------------------------------------
 <a name="encode"></a>

--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ function msgpack (options) {
   var encodingTypes = []
   var decodingTypes = []
 
-  options = options || { forceFloat64: false }
+  options = options || {
+    forceFloat64: false,
+    compatibilityMode: false
+  }
 
   function registerEncoder (check, encode) {
     assert(check, 'must have an encode function')
@@ -61,7 +64,7 @@ function msgpack (options) {
   }
 
   return {
-    encode: buildEncode(encodingTypes, options.forceFloat64),
+    encode: buildEncode(encodingTypes, options.forceFloat64, options.compatibilityMode),
     decode: buildDecode(decodingTypes),
     register: register,
     registerEncoder: registerEncoder,

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,7 +1,7 @@
 var bl = require('bl')
 var TOLERANCE = 0.1
 
-module.exports = function buildEncode (encodingTypes, forceFloat64) {
+module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilityMode) {
   function encode (obj, avoidSlice) {
     var buf,
       len
@@ -23,7 +23,8 @@ module.exports = function buildEncode (encodingTypes, forceFloat64) {
         buf = new Buffer(1 + len)
         buf[0] = 0xa0 | len
         buf.write(obj, 1)
-      } else if (len <= 0xff) {
+      } else if (len <= 0xff && !compatibilityMode) {
+        // str8, but only when not in compatibility mode
         buf = new Buffer(2 + len)
         buf[0] = 0xd9
         buf[1] = len

--- a/test/compatibility-mode.js
+++ b/test/compatibility-mode.js
@@ -1,0 +1,40 @@
+'use strict'
+
+var test = require('tape').test
+var msgpack = require('../')
+
+test('encode/compatibility mode', function (t) {
+  var compatEncoder = msgpack({
+    compatibilityMode: true
+  })
+  var defaultEncoder = msgpack({
+    compatibilityMode: false
+  })
+
+  var oneBytesStr = Array(31 + 2).join('x')
+  var twoBytesStr = Array(255 + 2).join('x')
+
+  t.test('default encoding a string of length ' + oneBytesStr.length, function (t) {
+    // Default: use 1 byte length string (str8)
+    var buf = defaultEncoder.encode(oneBytesStr)
+    t.equal(buf[0], 0xd9, 'must have the proper header (str8)')
+    t.equal(buf.toString('utf8', 2, Buffer.byteLength(oneBytesStr) + 2), oneBytesStr, 'must decode correctly')
+    t.end()
+  })
+
+  t.test('compat. encoding a string of length ' + oneBytesStr.length, function (t) {
+    // Compat. mode: use 2 byte length string (str16)
+    var buf = compatEncoder.encode(oneBytesStr)
+    t.equal(buf[0], 0xda, 'must have the proper header (str16)')
+    t.equal(buf.toString('utf8', 3, Buffer.byteLength(oneBytesStr) + 3), oneBytesStr, 'must decode correctly')
+    t.end()
+  })
+
+  t.test('encoding for a string of length ' + twoBytesStr.length, function (t) {
+    // Two byte strings: compat. mode should make no difference
+    var buf1 = defaultEncoder.encode(twoBytesStr)
+    var buf2 = compatEncoder.encode(twoBytesStr)
+    t.deepEqual(buf1, buf2, 'must be equal for two byte strings')
+    t.end()
+  })
+})


### PR DESCRIPTION
Introduced `compatibilityMode` option for decoder. 
If this option is `true`, the str8 date type will not be used, in order to solve problems with some decoders.

See issue #45 for more details.