### PR TITLE
Removing redundant keywords and adding MessagePack

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "msgpack",
     "extension",
     "v5",
-    "msgpack",
-    "v5",
+    "MessagePack",
     "ext"
   ],
   "author": "Matteo collina <hello@matteocollina.com>",


### PR DESCRIPTION
This should make the package easier to find when someone searches for "MessagePack" on the NPM site. I was looking for the defacto package and it took a bit long to discover this.

Also you can see the redundant keywords on the NPM page: https://www.npmjs.com/package/msgpack5