### PR TITLE
Update decoder.js [timestamp bugfix]

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -382,12 +382,12 @@ module.exports = function buildDecode (decodingTypes) {
     switch (size) {
       case 4:
           // timestamp 32 stores the number of seconds that have elapsed since 1970-01-01 00:00:00 UTC in an 32-bit unsigned integer
-        seconds = buf.readUInt32BE()
+        seconds = buf.readUInt32BE(0)
         break
 
       case 8: // Timestamp 64 stores the number of seconds and nanoseconds that have elapsed
                 // since 1970-01-01 00:00:00 UTC in 32-bit unsigned integers, split 30/34 bits
-        var upper = buf.readUInt32BE()
+        var upper = buf.readUInt32BE(0)
         var lower = buf.readUInt32BE(4)
         nanoseconds = upper / 4
         seconds = ((upper & 0x03) * Math.pow(2, 32)) + lower // If we use bitwise operators, we get truncated to 32bits


### PR DESCRIPTION
[FIXED] Lack of offsets presents errors when trying to decode timestamps.