### PR TITLE
support for map32

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -242,7 +242,8 @@ module.exports = function buildDecode (decodingTypes) {
         length = buf.readUInt16BE(offset + 1)
         return decodeMap(buf, offset, length, 3)
       case 0xdf:
-        throw new Error('map too big to decode in JS')
+        length = buf.readUInt32BE(offset + 1)
+        return decodeMap(buf, offset, length, 5)
       case 0xd4:
         return decodeFixExt(buf, offset, 1)
       case 0xd5:

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -248,10 +248,14 @@ module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilit
     if (length < 16) {
       header = Buffer.allocUnsafe(1)
       header[0] = 0x80 | length
-    } else {
+    } else if (length < 0xFFFF) {
       header = Buffer.allocUnsafe(3)
       header[0] = 0xde
       header.writeUInt16BE(length, 1)
+    } else {
+      header = Buffer.allocUnsafe(5)
+      header[0] = 0xdf
+      header.writeUInt32BE(length, 1)
     }
 
     acc.unshift(header)

--- a/test/object-with-many-keys.js
+++ b/test/object-with-many-keys.js
@@ -1,0 +1,71 @@
+'use strict'
+
+var test = require('tape').test
+var msgpack = require('../')
+
+test('encode/decode map with 10 keys', function (t) {
+  var map = {}
+
+  for (var i = 0; i < 10; i++) {
+    map[i] = i
+  }
+
+  var pack = msgpack()
+
+  var encoded = pack.encode(map)
+
+  // map16 byte
+  t.equal(encoded[0], 0x8A)
+
+  t.deepEqual(pack.decode(encoded), map)
+  t.end()
+})
+
+test('encode/decode map with 10000 keys', function (t) {
+  var map = {}
+
+  for (var i = 0; i < 10000; i++) {
+    map[i] = i
+  }
+
+  var pack = msgpack()
+
+  var encoded = pack.encode(map)
+
+  // map16 byte
+  t.equal(encoded[0], 0xde)
+
+  t.deepEqual(pack.decode(encoded), map)
+  t.end()
+})
+
+test('encode/decode map with 100000 keys', function (t) {
+  var map = {}
+
+  for (var i = 0; i < 100000; i++) {
+    map[i] = i
+  }
+
+  var pack = msgpack()
+
+  var encoded = pack.encode(map)
+
+  // map32 byte
+  t.equal(encoded[0], 0xdf)
+
+  t.deepEqual(pack.decode(encoded), map)
+  t.end()
+})
+
+test('encode/decode map with 1000000 keys', function (t) {
+  var map = {}
+
+  for (var i = 0; i < 1000000; i++) {
+    map[i] = i
+  }
+
+  var pack = msgpack()
+
+  t.deepEqual(pack.decode(pack.encode(map)), map)
+  t.end()
+})


### PR DESCRIPTION
This adds support and test for map32 - a map with items of up to
length 2^32-1

A few tests were added to check that the support is working as
expected.

Fixes #54