### PR TITLE
fix buffer allocation warnings

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -159,7 +159,7 @@ module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilit
 
     if (nanos || seconds > 0xFFFFFFFF) {
         // Timestamp64
-      encoded = new Buffer(10)
+      encoded = Buffer.allocUnsafe(10)
       encoded[0] = 0xd7
       encoded[1] = -1
 
@@ -172,7 +172,7 @@ module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilit
       encoded.writeInt32BE(lower, 6)
     } else {
         // Timestamp32
-      encoded = new Buffer(6)
+      encoded = Buffer.allocUnsafe(6)
       encoded[0] = 0xd6
       encoded[1] = -1
       encoded.writeUInt32BE(Math.floor(millis / 1000), 2)

--- a/test/1-byte-length-uint8arrays.js
+++ b/test/1-byte-length-uint8arrays.js
@@ -34,7 +34,7 @@ test('encode/decode 2^8-1 Uint8Arrays', function (t) {
     })
 
     t.test('mirror test for an Uint8Array of length ' + array.byteLength + ' bytes', function (t) {
-      t.deepEqual(encoder.decode(encoder.encode(array)), new Buffer(array), 'must stay the same')
+      t.deepEqual(encoder.decode(encoder.encode(array)), Buffer.from(array), 'must stay the same')
       t.end()
     })
   })

--- a/test/2-bytes-length-uint8arrays.js
+++ b/test/2-bytes-length-uint8arrays.js
@@ -34,7 +34,7 @@ test('encode/decode 2^8-1 Uint8Arrays', function (t) {
     })
 
     t.test('mirror test for an Uint8Array of length ' + array.byteLength + ' bytes', function (t) {
-      t.deepEqual(encoder.decode(encoder.encode(array)), new Buffer(array), 'must stay the same')
+      t.deepEqual(encoder.decode(encoder.encode(array)), Buffer.from(array), 'must stay the same')
       t.end()
     })
   })

--- a/test/4-bytes-length-uint8arrays.js
+++ b/test/4-bytes-length-uint8arrays.js
@@ -33,7 +33,7 @@ test('encode/decode 2^8-1 Uint8Arrays', function (t) {
     })
 
     t.test('mirror test for an Uint8Array of length ' + array.byteLength + ' bytes', function (t) {
-      t.deepEqual(encoder.decode(encoder.encode(array)), new Buffer(array), 'must stay the same')
+      t.deepEqual(encoder.decode(encoder.encode(array)), Buffer.from(array), 'must stay the same')
       t.end()
     })
   })


### PR DESCRIPTION
`new Buffer` is not supported and is marked as deprecated, creating
some deprecation warnings.

this switches those calls to `Buffer.allocUnsafe`