### PR TITLE
implement better support for floats

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -2,7 +2,6 @@
 
 var Buffer = require('safe-buffer').Buffer
 var bl = require('bl')
-var TOLERANCE = 0.1
 
 module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilityMode, disableTimestampEncoding) {
   function encode (obj, avoidSlice) {
@@ -301,22 +300,35 @@ function write64BitInt (buf, offset, num) {
 }
 
 function isFloat (n) {
-  return n !== Math.floor(n)
+  return n % 1 !== 0
 }
 
 function encodeFloat (obj, forceFloat64) {
+  var useDoublePrecision = true
+
+  // If `fround` is supported, we can check if a float
+  // is double or single precision by rounding the object
+  // to single precision and comparing the difference.
+  // If it's not supported, it's safer to use a 64 bit
+  // float so we don't lose precision without meaning to.
+  if (Math.fround) {
+    useDoublePrecision = Math.fround(obj) !== obj
+  }
+
+  if (forceFloat64) {
+    useDoublePrecision = true
+  }
+
   var buf
 
-  buf = Buffer.allocUnsafe(5)
-  buf[0] = 0xca
-  buf.writeFloatBE(obj, 1)
-
-  // FIXME is there a way to check if a
-  // value fits in a float?
-  if (forceFloat64 || Math.abs(obj - buf.readFloatBE(1)) > TOLERANCE) {
+  if (useDoublePrecision) {
     buf = Buffer.allocUnsafe(9)
     buf[0] = 0xcb
     buf.writeDoubleBE(obj, 1)
+  } else {
+    buf = Buffer.allocUnsafe(5)
+    buf[0] = 0xca
+    buf.writeFloatBE(obj, 1)
   }
 
   return buf

--- a/test/floats.js
+++ b/test/floats.js
@@ -7,29 +7,67 @@ var bl = require('bl')
 
 test('encoding/decoding 32-bits float numbers', function (t) {
   var encoder = msgpack()
-  var allNum = []
+  var float32 = [
+    1.5,
+    0.15625,
+    -2.5
+  ]
 
-  allNum.push(-222.42)
-  allNum.push(748364.2)
-  allNum.push(2.2)
+  var float64 = [
+    2 ** 150,
+    1.337,
+    2.2
+  ]
 
-  allNum.forEach(function (num) {
+  float64.forEach(function (num) {
     t.test('encoding ' + num, function (t) {
       var buf = encoder.encode(num)
-      var dec = buf.readFloatBE(1)
+      t.equal(buf.length, 9, 'must have 5 bytes')
+      t.equal(buf[0], 0xcb, 'must have the proper header')
+
+      var dec = buf.readDoubleBE(1)
+      t.equal(dec, num, 'must decode correctly')
+      t.end()
+    })
+
+    t.test('decoding ' + num, function (t) {
+      var buf = Buffer.allocUnsafe(9)
+      var dec
+      buf[0] = 0xcb
+      buf.writeDoubleBE(num, 1)
+
+      dec = encoder.decode(buf)
+      t.equal(dec, num, 'must decode correctly')
+      t.end()
+    })
+
+    t.test('mirror test ' + num, function (t) {
+      var dec = encoder.decode(encoder.encode(num))
+      t.equal(dec, num, 'must decode correctly')
+      t.end()
+    })
+  })
+
+  float32.forEach(function (num) {
+    t.test('encoding ' + num, function (t) {
+      var buf = encoder.encode(num)
       t.equal(buf.length, 5, 'must have 5 bytes')
       t.equal(buf[0], 0xca, 'must have the proper header')
-      t.true(Math.abs(dec - num) < 0.1, 'must decode correctly')
+
+      var dec = buf.readFloatBE(1)
+      t.equal(dec, num, 'must decode correctly')
       t.end()
     })
 
     t.test('forceFloat64 encoding ' + num, function (t) {
       var enc = msgpack({ forceFloat64: true })
       var buf = enc.encode(num)
-      var dec = buf.readDoubleBE(1)
+
       t.equal(buf.length, 9, 'must have 9 bytes')
       t.equal(buf[0], 0xcb, 'must have the proper header')
-      t.true(Math.abs(dec - num) < 0.1, 'must decode correctly')
+
+      var dec = buf.readDoubleBE(1)
+      t.equal(dec, num, 'must decode correctly')
       t.end()
     })
 
@@ -38,14 +76,15 @@ test('encoding/decoding 32-bits float numbers', function (t) {
       var dec
       buf[0] = 0xca
       buf.writeFloatBE(num, 1)
+
       dec = encoder.decode(buf)
-      t.true(Math.abs(dec - num) < 0.1, 'must decode correctly')
+      t.equal(dec, num, 'must decode correctly')
       t.end()
     })
 
     t.test('mirror test ' + num, function (t) {
       var dec = encoder.decode(encoder.encode(num))
-      t.true(Math.abs(dec - num) < 0.1, 'must decode correctly')
+      t.equal(dec, num, 'must decode correctly')
       t.end()
     })
   })
@@ -57,6 +96,19 @@ test('decoding an incomplete 32-bits float numbers', function (t) {
   var encoder = msgpack()
   var buf = Buffer.allocUnsafe(4)
   buf[0] = 0xca
+  buf = bl().append(buf)
+  var origLength = buf.length
+  t.throws(function () {
+    encoder.decode(buf)
+  }, encoder.IncompleteBufferError, 'must throw IncompleteBufferError')
+  t.equals(buf.length, origLength, 'must not consume any byte')
+  t.end()
+})
+
+test('decoding an incomplete 64-bits float numbers', function (t) {
+  var encoder = msgpack()
+  var buf = Buffer.allocUnsafe(8)
+  buf[0] = 0xcb
   buf = bl().append(buf)
   var origLength = buf.length
   t.throws(function () {


### PR DESCRIPTION
this change uses `fround` when available to make a better decision on
if a number is a 32 or 64 bit floating point number.  This means that
we can more safely use floats in msgpack without losing precision.

In the case where `Math.fround` is not defined (I'M LOOKIN AT YOU, IE10),
this code defaults to using a float64 so that we don't accidentally lose
precision like we did with the previous implementation