### PR TITLE
Add support for encoding and decoding timestamp96 data

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function msgpack (options) {
     disableTimestampEncoding: false,
     // if true, will throw error when decoding a timestamp96 that
     // is more precise, or greater than or lower than the number
-    // of seconds JavaScript Date can handle
+    // of seconds JavaScript Date can handle or if nanoseconds > 999999999
     timestamp96ThrowRangeEx: false
   }
 
@@ -29,7 +29,7 @@ function msgpack (options) {
     assert(check, 'must have an encode function')
     assert(encode, 'must have an encode function')
 
-    encodingTypes.push({ check, encode })
+    encodingTypes.push({ check: check, encode: encode })
 
     return this
   }
@@ -72,16 +72,16 @@ function msgpack (options) {
   return {
     encode: buildEncode(encodingTypes, options.forceFloat64, options.compatibilityMode, options.disableTimestampEncoding),
     decode: buildDecode(decodingTypes, options.timestamp96ThrowRangeEx),
-    register,
-    registerEncoder,
-    registerDecoder,
+    register: register,
+    registerEncoder: registerEncoder,
+    registerDecoder: registerDecoder,
     encoder: streams.encoder,
     decoder: streams.decoder,
     // needed for levelup support
     buffer: true,
     type: 'msgpack5',
-    IncompleteBufferError,
-    OutOfRangeError
+    IncompleteBufferError: IncompleteBufferError,
+    OutOfRangeError: OutOfRangeError
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var streams = require('./lib/streams')
 var buildDecode = require('./lib/decoder')
 var buildEncode = require('./lib/encoder')
 var IncompleteBufferError = require('./lib/helpers.js').IncompleteBufferError
+var OutOfRangeError = require('./lib/helpers.js').OutOfRangeError
 
 function msgpack (options) {
   var encodingTypes = []
@@ -17,7 +18,11 @@ function msgpack (options) {
     compatibilityMode: false,
     // if true, skips encoding Dates using the msgpack
     // timestamp ext format (-1)
-    disableTimestampEncoding: false
+    disableTimestampEncoding: false,
+    // if true, will throw error when decoding a timestamp96 that
+    // is more precise, or greater than or lower than the number
+    // of seconds JavaScript Date can handle
+    timestamp96ThrowRangeEx: false
   }
 
   function registerEncoder (check, encode) {
@@ -66,7 +71,7 @@ function msgpack (options) {
 
   return {
     encode: buildEncode(encodingTypes, options.forceFloat64, options.compatibilityMode, options.disableTimestampEncoding),
-    decode: buildDecode(decodingTypes),
+    decode: buildDecode(decodingTypes, options.timestamp96ThrowRangeEx),
     register,
     registerEncoder,
     registerDecoder,
@@ -75,7 +80,8 @@ function msgpack (options) {
     // needed for levelup support
     buffer: true,
     type: 'msgpack5',
-    IncompleteBufferError
+    IncompleteBufferError,
+    OutOfRangeError
   }
 }
 

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -5,7 +5,7 @@ var helpers = require('./helpers.js')
 var IncompleteBufferError = helpers.IncompleteBufferError
 var decodeTimestamp = helpers.decodeTimestamp
 
-const SIZES = {
+var SIZES = {
   0xc4: 2,
   0xc5: 3,
   0xc6: 5,
@@ -59,52 +59,56 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
   function tryDecode (buf, initialOffset) {
     if (buf.length <= initialOffset) return null
 
-    const bufLength = buf.length - initialOffset
+    var bufLength = buf.length - initialOffset
     var offset = initialOffset
 
-    const first = buf.readUInt8(offset)
+    var first = buf.readUInt8(offset)
     offset += 1
 
-    const size = SIZES[first] || -1
+    var size = SIZES[first] || -1
     if (bufLength < size) return null
 
-    const inRange = (start, end) => first >= start && first <= end
+    var inRange = function (start, end) {
+      return first >= start && first <= end
+    }
 
+    var length = 0
+    var headerSize = 0
     if (first < 0x80) return [first, 1] // 7-bits positive ints
     if ((first & 0xf0) === 0x80) {
-      const length = first & 0x0f
-      const headerSize = offset - initialOffset
+      length = first & 0x0f
+      headerSize = offset - initialOffset
       // we have an array with less than 15 elements
       return decodeMap(buf, initialOffset, length, headerSize)
     }
     if ((first & 0xf0) === 0x90) {
-      const length = first & 0x0f
-      const headerSize = offset - initialOffset
+      length = first & 0x0f
+      headerSize = offset - initialOffset
       // we have a map with less than 15 elements
       return decodeArray(buf, offset, length, headerSize)
     }
 
     if ((first & 0xe0) === 0xa0) {
       // fixstr up to 31 bytes
-      const length = first & 0x1f
+      length = first & 0x1f
       if (!isValidDataSize(length, bufLength, 1)) return null
-      const result = buf.toString('utf8', offset, offset + length)
+      var result = buf.toString('utf8', offset, offset + length)
       return [result, length + 1]
     }
     if (inRange(0xc0, 0xc3)) return decodeConstants(first)
     if (inRange(0xc4, 0xc6)) {
-      const length = buf.readUIntBE(offset, size - 1)
+      length = buf.readUIntBE(offset, size - 1)
       offset += size - 1
 
       if (!isValidDataSize(length, bufLength, size)) return null
-      const result = buf.slice(offset, offset + length)
+      result = buf.slice(offset, offset + length)
       return [result, size + length]
     }
     if (inRange(0xc7, 0xc9)) {
-      const length = buf.readUIntBE(offset, size - 2)
+      length = buf.readUIntBE(offset, size - 2)
       offset += size - 2
 
-      const type = buf.readInt8(offset)
+      var type = buf.readInt8(offset)
       offset += 1
 
       if (!isValidDataSize(length, bufLength, size)) return null
@@ -114,26 +118,25 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
     if (inRange(0xcc, 0xcf)) return decodeUnsignedInt(buf, offset, size - 1)
     if (inRange(0xd0, 0xd3)) return decodeSigned(buf, offset, size - 1)
     if (inRange(0xd4, 0xd8)) {
-      var type = buf.readInt8(offset) // Signed
+      type = buf.readInt8(offset) // Signed
       offset += 1
       return decodeExt(buf, offset, type, size - 2, 2)
     }
 
     if (inRange(0xd9, 0xdb)) {
-      const length = buf.readUIntBE(offset, size - 1)
+      length = buf.readUIntBE(offset, size - 1)
       offset += size - 1
 
       if (!isValidDataSize(length, bufLength, size)) return null
-      const result = buf.toString('utf8', offset, offset + length)
+      result = buf.toString('utf8', offset, offset + length)
       return [result, size + length]
     }
     if (inRange(0xdc, 0xdd)) {
-      const length = buf.readUIntBE(offset, size - 1)
+      length = buf.readUIntBE(offset, size - 1)
       offset += size - 1
       return decodeArray(buf, offset, length, size)
     }
     if (inRange(0xde, 0xdf)) {
-      let length
       switch (first) {
         case 0xde:
           // maps up to 2^16 elements - 2 bytes
@@ -155,7 +158,7 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
 
   function decodeArray (buf, initialOffset, length, headerLength) {
     var offset = initialOffset
-    const result = []
+    var result = []
     var i = 0
 
     while (i++ < length) {
@@ -170,7 +173,7 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
 
   function decodeMap (buf, initialOffset, length, headerLength) {
     var offset = initialOffset + headerLength
-    const result = {}
+    var result = {}
     var i = 0
 
     while (i++ < length) {
@@ -206,7 +209,7 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
   }
 
   function decodeUnsignedInt (buf, offset, size) {
-    const maxOffset = offset + size
+    var maxOffset = offset + size
     var result = 0
     while (offset < maxOffset) { result += buf.readUInt8(offset++) * Math.pow(256, maxOffset - offset) }
     return [result, size + 1]
@@ -235,12 +238,12 @@ module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
   }
 
   function decodeExt (buf, offset, type, size, headerSize) {
-    const toDecode = buf.slice(offset, offset + size)
+    var toDecode = buf.slice(offset, offset + size)
 
     // Pre-defined  (type < 0) Reserved for future extensions
     if (type === -1) return decodeTimestamp(toDecode, size, headerSize, timestamp96ThrowRangeEx)
 
-    const decode = decodingTypes[type]
+    var decode = decodingTypes[type]
     if (!decode) throw new Error('unable to find ext type ' + type)
 
     var value = decode(toDecode)

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -39,7 +39,7 @@ function isValidDataSize (dataLength, bufLength, headerLength) {
   return bufLength >= headerLength + dataLength
 }
 
-module.exports = function buildDecode (decodingTypes) {
+module.exports = function buildDecode (decodingTypes, timestamp96ThrowRangeEx) {
   return decode
 
   function decode (buf) {
@@ -238,7 +238,7 @@ module.exports = function buildDecode (decodingTypes) {
     const toDecode = buf.slice(offset, offset + size)
 
     // Pre-defined  (type < 0) Reserved for future extensions
-    if (type === -1) return decodeTimestamp(toDecode, size, headerSize)
+    if (type === -1) return decodeTimestamp(toDecode, size, headerSize, timestamp96ThrowRangeEx)
 
     const decode = decodingTypes[type]
     if (!decode) throw new Error('unable to find ext type ' + type)

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -158,7 +158,21 @@ module.exports = function buildEncode (encodingTypes, forceFloat64, compatibilit
     var seconds = Math.floor(millis / 1000)
     var nanos = (millis - (seconds * 1000)) * 1E6
 
-    if (nanos || seconds > 0xFFFFFFFF) {
+    if (seconds >= Math.pow(2, 34) || seconds < 0) {
+      // Timestamp96
+      encoded = Buffer.allocUnsafe(15)
+      encoded[0] = 0xc7
+      encoded[1] = 12
+      encoded[2] = -1
+
+      var upper96 = Math.floor(seconds / Math.pow(2, 32))
+      var posSec = seconds
+      var lower96 = posSec & 0xFFFFFFFF
+
+      encoded.writeInt32BE(nanos, 3)
+      encoded.writeInt32BE(upper96, 7)
+      encoded.writeInt32BE(lower96, 11)
+    } else if (nanos || seconds > 0xFFFFFFFF) {
       // Timestamp64
       encoded = Buffer.allocUnsafe(10)
       encoded[0] = 0xd7

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,7 @@
 var util = require('util')
 var TIME_MAX = 864E10
 
-const fround = Math.fround
+var fround = Math.fround
 
 exports.IncompleteBufferError = IncompleteBufferError
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var util = require('util')
+var TIME_MAX = 864E10
 
 const fround = Math.fround
 
@@ -16,6 +17,19 @@ function IncompleteBufferError (message) {
 }
 
 util.inherits(IncompleteBufferError, Error)
+
+exports.OutOfRangeError = OutOfRangeError
+
+function OutOfRangeError (message) {
+  Error.call(this) // super constructor
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor) // super helper method to include stack trace in error object
+  }
+  this.name = this.constructor.name
+  this.message = message || 'unable to decode'
+}
+
+util.inherits(OutOfRangeError, Error)
 
 exports.isFloat = function isFloat (n) {
   return n % 1 !== 0
@@ -43,7 +57,7 @@ exports.encodeFloat = function encodeFloat (obj, forceFloat64) {
   return buf
 }
 
-exports.decodeTimestamp = function decodeTimestamp (buf, size, headerSize) {
+exports.decodeTimestamp = function decodeTimestamp (buf, size, headerSize, timestamp96ThrowRangeEx) {
   var seconds
   var nanoseconds = 0
 
@@ -63,10 +77,45 @@ exports.decodeTimestamp = function decodeTimestamp (buf, size, headerSize) {
       break
 
     case 12:
-      throw new Error('timestamp 96 is not yet implemented')
+      // Timestamp 96 stores the number of seconds and nanoseconds that have elapsed since 1970-01-01 00:00:00 UTC
+      // in 64-bit signed integer and 32-bit unsigned integer
+      nanoseconds = buf.readUInt32BE()
+      var upper96 = buf.readInt32BE(4)
+      var lower96 = buf.readUInt32BE(8)
+      seconds = (upper96 * Math.pow(2, 32)) + lower96 // If we use bitwise operators, we get truncated to 32bits
+      if (seconds > TIME_MAX) {
+        if (timestamp96ThrowRangeEx) {
+          throw new OutOfRangeError()
+        } else {
+          seconds = TIME_MAX // JS Date Max
+        }
+      } else if (seconds < -TIME_MAX) {
+        if (timestamp96ThrowRangeEx) {
+          throw new OutOfRangeError()
+        } else {
+          seconds = -TIME_MAX // JS Date Min
+        }
+      }
+
+      // Nanos are more precise than allowed
+      if ((nanoseconds % 1e6) && timestamp96ThrowRangeEx) {
+        throw new OutOfRangeError()
+      }
+
+      // Nanos are greater than allowed, 999999999
+      if ((nanoseconds >= 1e9)) {
+        if (timestamp96ThrowRangeEx) {
+          throw new OutOfRangeError()
+        } else {
+          nanoseconds = 1e9 - 1 // Set to max allowed nanos
+        }
+      }
+
+      break
   }
 
-  var millis = (seconds * 1000) + Math.round(nanoseconds / 1E6)
+  // Must be Math.floor(nanoseconds / 1E6) otherwise we could roll over max seconds
+  var millis = (seconds * 1000) + Math.floor(nanoseconds / 1E6)
 
   return [ new Date(millis), size + headerSize ]
 }

--- a/test/timestamps.js
+++ b/test/timestamps.js
@@ -24,47 +24,82 @@ test('timestamp disabling', function (t) {
 
   t.end()
 })
-test('encoding/decoding timestamp 64', function (t) {
+test('encoding/decoding timestamp 32/64/96', function (t) {
   var encoder = msgpack()
+  var encoderThrow = msgpack({ timestamp96ThrowRangeEx: true })
   var timestamps = [
-    [new Date('2018-01-02T03:04:05.000000000Z'), [0xd6, 0xff, 0x5a, 0x4a, 0xf6, 0xa5]],
-    [new Date('2038-01-19T03:14:08.000000000Z'), [0xd6, 0xff, 0x80, 0x00, 0x00, 0x00]],
-    [new Date('2038-01-19T03:14:07.999000000Z'), [0xd7, 0xff, 0xee, 0x2E, 0x1F, 0x00, 0x7f, 0xff, 0xff, 0xff]],
-    [new Date('2106-02-07T06:28:16.000000000Z'), [0xd7, 0xff, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]],
-    [new Date('2018-01-02T03:04:05.678000000Z'), [0xd7, 0xff, 0xa1, 0xa5, 0xd6, 0x00, 0x5a, 0x4a, 0xf6, 0xa5]]
+    [new Date('1970-01-01T00:00:00Z'), [0xd6, 0xff, 0x00, 0x00, 0x00, 0x00], false, 'Timestamp 32 - Min'],
+    [new Date('2106-02-07T06:28:15Z'), [0xd6, 0xff, 0xff, 0xff, 0xff, 0xff], false, 'Timestamp 32 - Max'],
+    [new Date('2018-01-02T03:04:05.000Z'), [0xd6, 0xff, 0x5a, 0x4a, 0xf6, 0xa5], false, 'Timestamp 32'],
+    [new Date('2038-01-19T03:14:08.000Z'), [0xd6, 0xff, 0x80, 0x00, 0x00, 0x00], false, 'Timestamp 32'],
+    [new Date('2038-01-19T03:14:07.999Z'), [0xd7, 0xff, 0xee, 0x2E, 0x1F, 0x00, 0x7f, 0xff, 0xff, 0xff], false, 'Timestamp 64 - has nano seconds'],
+    [new Date('2106-02-07T06:28:16.000Z'), [0xd7, 0xff, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00], false, 'Timestamp 64 - is larger than Timestamp 32 can hold'],
+    [new Date('2018-01-02T03:04:05.678Z'), [0xd7, 0xff, 0xa1, 0xa5, 0xd6, 0x00, 0x5a, 0x4a, 0xf6, 0xa5], false, 'Timestamp 64 - has nano seconds2'],
+    [new Date('2514-05-30T01:53:04.000Z'), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00], false, 'Timestamp 96 - is larger than TimeStamp 64 can hold for seconds'],
+    [new Date('1969-12-31T23:59:59.000Z'), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], false, 'Timestamp 96 - is smaller than TimeStamp 64 can hold for seconds'],
+    [new Date(8640000000000000), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0xdb, 0xa8, 0x21, 0x80, 0x00], false, 'Timestamp 96 JavaScript - Max Date (Real Timestamp96)'],
+    [new Date(-8640000000000000), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xf8, 0x24, 0x57, 0xde, 0x80, 0x00], false, 'Timestamp 96 JavaScript - Min Date (Real Timestamp96)'],
+    [new Date(0), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], true, 'Timestamp 96 - is more precise than TimeStamp 64 can hold for nanoseconds'],
+    [new Date(999), [0xc7, 0x0c, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], true, 'Timestamp 96 - invalid nanoseconds e.g. > 999999999'],
+    [new Date(8640000000000000), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], true, 'Timestamp 96 JavaScript - Max Date (Max Timestamp96) - should throw error if set, round otherwise'],
+    [new Date(-8640000000000000), [0xc7, 0x0c, 0xff, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], true, 'Timestamp 96 JavaScript - Min Date (Min Timestamp96) - should throw error if set, round otherwise']
   ]
 
   timestamps.forEach(function (testcase) {
     var item = testcase[0]
     var expected = testcase[1]
+    var outOfRange = testcase[2]
+    var testName = testcase[3] + ': '
 
-    t.test('encoding ' + item.toString(), function (t) {
-      var buf = encoder.encode(item).slice()
-      t.equal(buf.length, expected.length, 'must have ' + expected.length + ' bytes')
-      switch (expected.length) {
-        case 6:
-          t.equal(buf[0], 0xd6, 'must have the correct header')
-          break
-        case 10:
-          t.equal(buf[0], 0xd7, 'must have the correct header')
-          break
-      }
-      t.equal(buf.readInt8(1), -1, 'must have the correct type') // Signed
-      for (var j = 2; j < buf.length; j++) {
-        t.equal(buf[j], expected[j], 'byte ' + (j - 2) + ' match')
-      }
-      t.end()
-    })
+    if (outOfRange) {
+      // Test decoding with timestamp96ThrowRangeEx = true
+      t.test('decoding out of range ' + item, function (t) {
+        var buf = Buffer.from(expected)
 
+        t.throws(function () {
+          encoderThrow.decode(buf)
+        }, encoder.OutOfRangeError, testName + 'must throw OutOfRangeError')
+
+        t.end()
+      })
+    } else {
+      t.test('encoding ' + item.toString(), function (t) {
+        var buf = encoder.encode(item).slice()
+        t.equal(buf.length, expected.length, testName + 'must have ' + expected.length + ' bytes got ' + buf.length + 'bytes for date ' + item)
+        switch (expected.length) {
+          case 6:
+            t.equal(buf[0], 0xd6, 'must have the correct header')
+            t.equal(buf.readInt8(1), -1, testName + 'must have the correct type') // Signed
+            break
+          case 10:
+            t.equal(buf[0], 0xd7, 'must have the correct header')
+            t.equal(buf.readInt8(1), -1, testName + 'must have the correct type') // Signed
+            break
+          case 15:
+            t.equal(buf[0], 0xc7, 'must have the correct header')
+            t.equal(buf[1], 12, 'must have the correct header')
+            t.equal(buf.readInt8(2), -1, testName + 'must have the correct type') // Signed
+            break
+        }
+        for (var j = 2; j < buf.length; j++) {
+          t.equal(buf[j], expected[j], testName + 'byte ' + (j - 2) + ' match')
+        }
+        t.end()
+      })
+
+      // Only want to mirror test when comparing values that don't have range issues
+      t.test('mirror test ' + item, function (t) {
+        t.equal(encoder.decode(encoder.encode(item)) * 1, item * 1, testName + 'must stay the same')
+        t.end()
+      })
+    }
+
+    // Test normal decoding, timestamp96ThrowRangeEx = false (default)
     t.test('decoding ' + item, function (t) {
       var buf = Buffer.from(expected)
-      var dt = encoder.decode(buf)
-      t.equal(dt.toString(), item.toString(), 'must decode correctly\nDecoded:\t' + dt * 1 + '\nExp:\t' + item * 1)
-      t.end()
-    })
 
-    t.test('mirror test ' + item, function (t) {
-      t.equal(encoder.decode(encoder.encode(item)) * 1, item * 1, 'must stay the same')
+      var dt = encoder.decode(buf)
+      t.equal(dt * 1, item * 1, testName + 'must decode correctly\nDecoded:\t' + dt * 1 + '\nExp:\t' + item * 1)
       t.end()
     })
   })


### PR DESCRIPTION
- New option timestamp96ThrowRangeEx to throw errors in invalid cases. Default behavior is to trim precision without throwing an error
- Fix test cases to compare number of ms not strings as strings by default don't include ms accuracy
- Add new test cases

When working with SignalR Core and MessagePack-CSharp this should now let you handle C#'s full range. 
