### PR TITLE
Add option to prefer decoding as Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ options:
 - `sortKeys`, a boolean to force a determinate keys order
 - `compatibilityMode`, a boolean that enables "compatibility mode" which doesn't use str 8 format. Defaults to false.
 - `disableTimestampEncoding`, a boolean that when set disables the encoding of Dates into the [timestamp extension type](https://github.com/msgpack/msgpack/blob/master/spec.md#timestamp-extension-type). Defaults to false.
+- `preferMap`, a boolean that forces all maps to be decoded to `Map`s rather than plain objects. This ensures that `decode(encode(new Map())) instanceof Map` and that iteration order is preserved. Defaults to false.
 
 -------------------------------------------------------
 <a name="encode"></a>

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ function msgpack (options) {
     compatibilityMode: false,
     // if true, skips encoding Dates using the msgpack
     // timestamp ext format (-1)
-    disableTimestampEncoding: false
+    disableTimestampEncoding: false,
+    preferMap: false
   }
 
   decodingTypes.set(DateCodec.type, DateCodec.decode)
@@ -72,7 +73,7 @@ function msgpack (options) {
 
   return {
     encode: buildEncode(encodingTypes, options),
-    decode: buildDecode(decodingTypes),
+    decode: buildDecode(decodingTypes, options),
     register,
     registerEncoder,
     registerDecoder,

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -37,7 +37,7 @@ function isValidDataSize (dataLength, bufLength, headerLength) {
   return bufLength >= headerLength + dataLength
 }
 
-module.exports = function buildDecode (decodingTypes) {
+module.exports = function buildDecode (decodingTypes, options) {
   return decode
 
   function decode (buf) {
@@ -72,13 +72,13 @@ module.exports = function buildDecode (decodingTypes) {
     if ((first & 0xf0) === 0x80) {
       const length = first & 0x0f
       const headerSize = offset - initialOffset
-      // we have an array with less than 15 elements
-      return decodeMap(buf, offset, length, headerSize)
+      // we have a map with less than 15 elements
+      return decodeMap(buf, offset, length, headerSize, options)
     }
     if ((first & 0xf0) === 0x90) {
       const length = first & 0x0f
       const headerSize = offset - initialOffset
-      // we have a map with less than 15 elements
+      // we have an array with less than 15 elements
       return decodeArray(buf, offset, length, headerSize)
     }
 
@@ -138,12 +138,12 @@ module.exports = function buildDecode (decodingTypes) {
           length = buf.readUInt16BE(offset)
           offset += 2
           // console.log(offset - initialOffset)
-          return decodeMap(buf, offset, length, 3)
+          return decodeMap(buf, offset, length, 3, options)
 
         case 0xdf:
           length = buf.readUInt32BE(offset)
           offset += 4
-          return decodeMap(buf, offset, length, 5)
+          return decodeMap(buf, offset, length, 5, options)
       }
     }
     if (first >= 0xe0) return [first - 0x100, 1] // 5 bits negative ints
@@ -166,16 +166,19 @@ module.exports = function buildDecode (decodingTypes) {
     return [result, headerLength + offset - initialOffset]
   }
 
-  function decodeMap (buf, offset, length, headerLength) {
+  function decodeMap (buf, offset, length, headerLength, options) {
     const _temp = decodeArray(buf, offset, 2 * length, headerLength)
     if (!_temp) return null
     const [ result, consumedBytes ] = _temp
 
-    var isPlainObject = true
-    for (let i = 0; i < 2 * length; i += 2) {
-      if (typeof result[i] !== 'string') {
-        isPlainObject = false
-        break
+    var isPlainObject = !options.preferMap
+
+    if (isPlainObject) {
+      for (let i = 0; i < 2 * length; i += 2) {
+        if (typeof result[i] !== 'string') {
+          isPlainObject = false
+          break
+        }
       }
     }
 

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -62,8 +62,10 @@ function encodeMap (map, options, encode) {
   const acc = [ getHeader(map.size, 0x80, 0xde) ]
   const keys = [ ...map.keys() ]
 
-  if (keys.every(item => typeof item === 'string')) {
-    console.warn('Map with string only keys will be deserialized as an object!')
+  if (!options.preferMap) {
+    if (keys.every(item => typeof item === 'string')) {
+      console.warn('Map with string only keys will be deserialized as an object!')
+    }
   }
 
   keys.forEach(key => {

--- a/test/prefer-map.js
+++ b/test/prefer-map.js
@@ -33,11 +33,20 @@ test('user can still encode objects as ext maps', function (t) {
   const encoder = msgpack({preferMap: true})
   const tag = 0x42
 
+  // Polyfill Object.fromEntries for node 10
+  const fromEntries = Object.fromEntries || (iterable => {
+    const object = {}
+    for (const [property, value] of iterable) {
+      object[property] = value
+    }
+    return object
+  })
+
   encoder.register(
     tag,
     Object,
     obj => encoder.encode(new Map(Object.entries(obj))),
-    data => Object.fromEntries(encoder.decode(data))
+    data => fromEntries(encoder.decode(data))
   )
 
   const inputs = [

--- a/test/prefer-map.js
+++ b/test/prefer-map.js
@@ -1,0 +1,62 @@
+const test = require('tape').test
+const msgpack = require('../')
+
+const map = new Map()
+  .set('a', 1)
+  .set('1', 'hello')
+  .set('world', 2)
+  .set('0', 'again')
+  .set('01', null)
+
+test('round-trip string-keyed Maps', function (t) {
+  const encoder = msgpack({preferMap: true})
+
+  for (const input of [new Map(), map]) {
+    const result = encoder.decode(encoder.encode(input))
+    t.assert(result instanceof Map)
+    t.deepEqual(result, input)
+  }
+
+  t.end()
+})
+
+test('preserve iteration order of string-keyed Maps', function (t) {
+  const encoder = msgpack({preferMap: true})
+  const decoded = encoder.decode(encoder.encode(map))
+
+  t.deepEqual([...decoded.keys()], [...map.keys()])
+
+  t.end()
+})
+
+test('user can still encode objects as ext maps', function (t) {
+  const encoder = msgpack({preferMap: true})
+  const tag = 0x42
+
+  encoder.register(
+    tag,
+    Object,
+    obj => encoder.encode(new Map(Object.entries(obj))),
+    data => Object.fromEntries(encoder.decode(data))
+  )
+
+  const inputs = [
+    {},
+    new Map(),
+    {foo: 'bar'},
+    new Map().set('foo', 'bar'),
+    new Map().set(null, null),
+    {0: 'baz'},
+    ['baz']
+  ]
+
+  for (const input of inputs) {
+    const buf = encoder.encode(input)
+    const result = encoder.decode(buf)
+
+    t.deepEqual(result, input)
+    t.equal(Object.getPrototypeOf(result), Object.getPrototypeOf(input))
+  }
+
+  t.end()
+})


### PR DESCRIPTION
This PR adds an option, `preferMap`, which when set causes all MessagePack maps to be decoded to javascript `Map`s.

The preexisting default behavior is to decode as `Map` if non-string keys exist and as a plain object otherwise. This means that `decode(encode(new Map())` is `{}`, i.e., `Map`s do not round-trip reliably. It also prevents the user from reliably determining the order of entries in the encoded MessagePack map. (It's not clear to me if MessagePack intends users to care about map order, but the spec doesn't appear to prohibit it.) An example:

```js
const {decode, encode} = require('msgpack5')();
const map = new Map()
  .set('b', 1)
  .set('1', 2)
  .set('01', 3)
  .set('0', 4)
  .set('a', 5);
const buffer = encode(map); // <Buffer 85 a1 62 01 a1 31 02 a2 30 31 03 a1 30 04 a1 61 05>
const object = decode(map);
const keys = Object.keys(object); // ['0', '1', 'b', '01', 'a']
```
The `Map`'s order is reflected by the encoded data but replaced by js object traversal order in the decoded data.

With `preferMap: true`, `decode(encode(new Map())` is `new Map()`, and the example above decodes to a `Map` with key ordering `'b', '1', '01', '0', 'a'`.